### PR TITLE
fix: remove thread local from reader / writer

### DIFF
--- a/kbl24/src/main/java/com/foursoft/kblmodel/kbl24/KblWriter.java
+++ b/kbl24/src/main/java/com/foursoft/kblmodel/kbl24/KblWriter.java
@@ -36,9 +36,6 @@ import java.util.function.Consumer;
  */
 public final class KblWriter extends XMLWriter<KBLContainer> {
 
-    private static final ThreadLocal<KblWriter> localWriter = ThreadLocal.withInitial(
-            KblWriter::new);
-
     /**
      * create a default KblWriter with a default validation events logger {@link ValidationEventLogger}
      */
@@ -57,10 +54,14 @@ public final class KblWriter extends XMLWriter<KBLContainer> {
     }
 
     /**
-     * @return a thread local KblWriter object
+     * @return a new KblWriter for each call.
+     *
+     * @deprecated the thread local caching has been removed due to memory leaking issues. Create your
+     *    own {@link KblWriter} and cache it by yourself if necessary. Will be removed with a future release.
      */
+    @Deprecated
     public static KblWriter getLocalWriter() {
-        return localWriter.get();
+        return new KblWriter();
     }
 }
 


### PR DESCRIPTION
## Pull Request

- [x] I have checked for similar PRs.
- [x] I have read the [contributing guidelines](https://github.com/4Soft-de/kbl-model/blob/develop/.github/CONTRIBUTING.md).

### Changes

- [x] Code
- [x] Documentation
- [ ] Other: 

Closes: \<Put down the issue number if available or remove that line>

### Description

ThreadLocal caching of reader / writer caused memory leaks and there has been dropped.
