### PR TITLE
Removal of local KblReader / -Writer

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,8 +111,8 @@ More examples can be found [in the examples](https://github.com/4Soft-de/kbl-mod
 public class MyKblReader {
     public void readKblFile(final String pathToFile) throws JAXBException, IOException {
         try (final InputStream is = MyKblReader.class.getResourceAsStream(pathToFile)) {
-            final KblReader localReader = KblReader.getLocalReader();
-            final JaxbModel<KBLContainer, Identifiable> model = localReader.readModel(is);
+            final KblReader kblReader = new KblReader();
+            final JaxbModel<KBLContainer, Identifiable> model = kblReader.readModel(is);
 
             final KblConnectorOccurrence occurrence = model.getIdLookup()
                     .findById(KblConnectorOccurrence.class, "I1616")
@@ -191,10 +191,10 @@ public class MyKblWriter {
         contactPoint3.setId("SCHNUPSI");
         contactPoint3.setXmlId("id_1236");
 
-        final KblWriter localWriter = KblWriter.getLocalWriter();
+        final KblWriter kblWriter = new KblWriter();
 
         try (final FileOutputStream outputStream = new FileOutputStream(target)) {
-            localWriter.write(root, outputStream);
+            kblWriter.write(root, outputStream);
         }
     }
 }

--- a/kbl24/src/examples/java/MyKblReader.java
+++ b/kbl24/src/examples/java/MyKblReader.java
@@ -11,8 +11,8 @@ import java.util.Set;
 public class MyKblReader {
     public static void readKblFile(final String pathToFile) throws IOException {
         try (final InputStream is = MyKblReader.class.getResourceAsStream(pathToFile)) {
-            final KblReader localReader = KblReader.getLocalReader();
-            final JaxbModel<KBLContainer, Identifiable> model = localReader.readModel(is);
+            final KblReader kblReader = new KblReader();
+            final JaxbModel<KBLContainer, Identifiable> model = kblReader.readModel(is);
 
             final KblConnectorOccurrence occurrence = model.getIdLookup()
                     .findById(KblConnectorOccurrence.class, "I1616")
@@ -46,8 +46,8 @@ public class MyKblReader {
 
     public static void getBackReferences(final String pathToFile) throws IOException {
         try (final InputStream is = MyKblReader.class.getResourceAsStream(pathToFile)) {
-            final KblReader localReader = KblReader.getLocalReader();
-            final JaxbModel<KBLContainer, Identifiable> model = localReader.readModel(is);
+            final KblReader kblReader = new KblReader();
+            final JaxbModel<KBLContainer, Identifiable> model = kblReader.readModel(is);
             final KBLContainer container = model.getRootElement();
 
             final List<KblConnectorHousing> connectorHousings = container.getConnectorHousings();

--- a/kbl24/src/examples/java/MyKblWriter.java
+++ b/kbl24/src/examples/java/MyKblWriter.java
@@ -55,10 +55,10 @@ public class MyKblWriter {
         contactPoint3.setId("SCHNUPSI");
         contactPoint3.setXmlId("id_1236");
 
-        final KblWriter localWriter = KblWriter.getLocalWriter();
+        final KblWriter kblWriter = new KblWriter();
 
         try (final FileOutputStream outputStream = new FileOutputStream(target)) {
-            localWriter.write(root, outputStream);
+            kblWriter.write(root, outputStream);
         }
     }
 }

--- a/kbl24/src/main/java/com/foursoft/kblmodel/kbl24/KblReader.java
+++ b/kbl24/src/main/java/com/foursoft/kblmodel/kbl24/KblReader.java
@@ -65,14 +65,4 @@ public final class KblReader extends XMLReader<KBLContainer, Identifiable> {
         super(KBLContainer.class, Identifiable.class, Identifiable::getXmlId, validationEventConsumer);
     }
 
-    /**
-     * @return a new KblReader for each call.
-     *
-     * @deprecated the thread local caching has been removed due to memory leaking issues. Create your
-     *    own {@link KblReader} and cache it by yourself if necessary. Will be removed with a future release.
-     */
-    @Deprecated
-    public static KblReader getLocalReader() {
-        return new KblReader();
-    }
 }

--- a/kbl24/src/main/java/com/foursoft/kblmodel/kbl24/KblWriter.java
+++ b/kbl24/src/main/java/com/foursoft/kblmodel/kbl24/KblWriter.java
@@ -53,15 +53,5 @@ public final class KblWriter extends XMLWriter<KBLContainer> {
 
     }
 
-    /**
-     * @return a new KblWriter for each call.
-     *
-     * @deprecated the thread local caching has been removed due to memory leaking issues. Create your
-     *    own {@link KblWriter} and cache it by yourself if necessary. Will be removed with a future release.
-     */
-    @Deprecated
-    public static KblWriter getLocalWriter() {
-        return new KblWriter();
-    }
 }
 


### PR DESCRIPTION
## Pull Request

- [x] I have checked for similar PRs.
- [x] I have read the [contributing guidelines](https://github.com/4Soft-de/kbl-model/blob/develop/.github/CONTRIBUTING.md).

### Changes

- [x] Code
- [ ] Documentation
- [x] Other: Read Me / Example Files

### Description

Finally removed `getLocalReader` and `getLocalWriter` which have been deprecated with version v1.2.1. Also removed occurrences from the ReadMe and example files.