### PR TITLE
Make `HasPart` interface generic and add a setter for the `KblPart`

### DIFF
--- a/v24/src/main/java/com/foursoft/harness/kbl/v24/HasPart.java
+++ b/v24/src/main/java/com/foursoft/harness/kbl/v24/HasPart.java
@@ -25,8 +25,10 @@
  */
 package com.foursoft.harness.kbl.v24;
 
-public interface HasPart {
+public interface HasPart<T extends KblPart> {
 
-    KblPart getPart();
+    T getPart();
+
+    void setPart(T value);
 
 }

--- a/v24/src/main/resources/kbl24/KBL24_SR1-ext.xjb
+++ b/v24/src/main/resources/kbl24/KBL24_SR1-ext.xjb
@@ -26,9 +26,53 @@
         <inheritance:implements>com.foursoft.harness.kbl.v24.HasIdentification</inheritance:implements>
     </jxb:bindings>
 
+    <jxb:bindings multiple="true" node="//xs:complexType[@name='Accessory_occurrence']">
+        <inheritance:implements>com.foursoft.harness.kbl.v24.HasPart&lt;com.foursoft.harness.kbl.v24.KblAccessory&gt;</inheritance:implements>
+    </jxb:bindings>
+
+    <jxb:bindings multiple="true" node="//xs:complexType[@name='Assembly_part_occurrence']">
+        <inheritance:implements>com.foursoft.harness.kbl.v24.HasPart&lt;com.foursoft.harness.kbl.v24.KblAssemblyPart&gt;</inheritance:implements>
+    </jxb:bindings>
+
+    <jxb:bindings multiple="true" node="//xs:complexType[@name='Cavity_plug_occurrence']">
+        <inheritance:implements>com.foursoft.harness.kbl.v24.HasPart&lt;com.foursoft.harness.kbl.v24.KblCavityPlug&gt;</inheritance:implements>
+    </jxb:bindings>
+
+    <jxb:bindings multiple="true" node="//xs:complexType[@name='Cavity_seal_occurrence']">
+        <inheritance:implements>com.foursoft.harness.kbl.v24.HasPart&lt;com.foursoft.harness.kbl.v24.KblCavitySeal&gt;</inheritance:implements>
+    </jxb:bindings>
+
+    <jxb:bindings multiple="true" node="//xs:complexType[@name='Co_pack_occurrence']">
+        <inheritance:implements>com.foursoft.harness.kbl.v24.HasPart&lt;com.foursoft.harness.kbl.v24.KblCoPackPart&gt;</inheritance:implements>
+    </jxb:bindings>
+
+    <jxb:bindings multiple="true" node="//xs:complexType[@name='Component_box_occurrence']">
+        <inheritance:implements>com.foursoft.harness.kbl.v24.HasPart&lt;com.foursoft.harness.kbl.v24.KblComponentBox&gt;</inheritance:implements>
+    </jxb:bindings>
+
+    <jxb:bindings multiple="true" node="//xs:complexType[@name='Component_occurrence']">
+        <inheritance:implements>com.foursoft.harness.kbl.v24.HasPart&lt;com.foursoft.harness.kbl.v24.KblComponent&gt;</inheritance:implements>
+    </jxb:bindings>
+
+    <jxb:bindings multiple="true" node="//xs:complexType[@name='Connector_occurrence']">
+        <inheritance:implements>com.foursoft.harness.kbl.v24.HasPart&lt;com.foursoft.harness.kbl.v24.KblConnectorHousing&gt;</inheritance:implements>
+    </jxb:bindings>
+
+    <jxb:bindings multiple="true" node="//xs:complexType[@name='Fixing_occurrence']">
+        <inheritance:implements>com.foursoft.harness.kbl.v24.HasPart&lt;com.foursoft.harness.kbl.v24.KblFixing&gt;</inheritance:implements>
+    </jxb:bindings>
+
+    <jxb:bindings multiple="true" node="//xs:complexType[@name='General_wire_occurrence']">
+        <inheritance:implements>com.foursoft.harness.kbl.v24.HasPart&lt;com.foursoft.harness.kbl.v24.KblGeneralWire&gt;</inheritance:implements>
+    </jxb:bindings>
+
     <jxb:bindings multiple="true"
-                  node="//xs:complexType[@name='Accessory_occurrence' or @name='Assembly_part_occurrence' or @name='Cavity_plug_occurrence' or @name='Cavity_seal_occurrence' or @name='Co_pack_occurrence' or @name='Component_box_occurrence' or @name='Component_occurrence'  or @name='Connector_occurrence' or @name='Fixing_occurrence' or @name='General_wire_occurrence' or @name='Special_terminal_occurrence' or @name='Terminal_occurrence' or @name='Wire_protection_occurrence']">
-        <inheritance:implements>com.foursoft.harness.kbl.v24.HasPart</inheritance:implements>
+                  node="//xs:complexType[@name='Special_terminal_occurrence' or @name='Terminal_occurrence']">
+        <inheritance:implements>com.foursoft.harness.kbl.v24.HasPart&lt;com.foursoft.harness.kbl.v24.KblGeneralTerminal&gt;</inheritance:implements>
+    </jxb:bindings>
+
+    <jxb:bindings multiple="true" node="//xs:complexType[@name='Wire_protection_occurrence']">
+        <inheritance:implements>com.foursoft.harness.kbl.v24.HasPart&lt;com.foursoft.harness.kbl.v24.KblWireProtection&gt;</inheritance:implements>
     </jxb:bindings>
 
     <jxb:bindings multiple="true"


### PR DESCRIPTION
## Pull Request

- [x] I have checked for similar PRs.
- [x] I have read the [contributing guidelines](https://github.com/4Soft-de/kbl-model/blob/develop/.github/CONTRIBUTING.md).

### Changes

- [x] Code
- [ ] Documentation
- [x] Other: JAXB Binding Declaration

### Description

Made `HasPart` generic in order to allow adding the setter to the interface. Needed to adjust the JAXB Binding Declaration file for this to have multiple bindings instead of one.